### PR TITLE
Fix evaluation ordering

### DIFF
--- a/lib/with_ember_app/assets/builder.rb
+++ b/lib/with_ember_app/assets/builder.rb
@@ -9,7 +9,7 @@ module WithEmberApp
 
       # @return [String]
       def execute
-        [asset_links, globals_as_js].flatten.join.html_safe
+        [globals_as_js, asset_links].flatten.join.html_safe
       end
 
       private


### PR DESCRIPTION
If the ember payload is evaluated before the globals, then Ember code that is executed on evaluation will not have access to the globals.

This flips the ordering so that things should work.

## Post Merge

- [x] [Bump HRSC version](https://github.com/MammothHR/hrsc/pull/927)