### PR TITLE
Fix leaky state

### DIFF
--- a/lib/with_ember_app/adapter/file.rb
+++ b/lib/with_ember_app/adapter/file.rb
@@ -52,7 +52,7 @@ module WithEmberApp
         inferred_index_file.present? && ::File.file?(inferred_index_file)
       end
 
-      attr_lazy_reader :inferred_index_file do
+      def inferred_index_file
         dasherized_name = app_name.to_s.dasherize
         Rails.root.join '..', dasherized_name, 'dist', "#{ dasherized_name }.html"
       end

--- a/lib/with_ember_app/assets/builder.rb
+++ b/lib/with_ember_app/assets/builder.rb
@@ -28,11 +28,12 @@ module WithEmberApp
         names << name if name.present?
 
         names.reject { |row| row.blank? }
+        names
       end
 
       # @return [<String>]
       def asset_links
-        names.map { |app| WithEmberApp.fetch app }
+        all_names.map { |app| WithEmberApp.fetch app }
       end
 
       # @return [String]


### PR DESCRIPTION
There were two aspects that could result in very unpredictable application loading:
- the file adapter was caching the inferred index name on a singleton instance of its adapter.  This resulted in subsequent requests for `inferred_index_file` to point to the last successful index file
- the asset builder was sometimes ignoring the `name` input

As a result, if Rails saw one Ember app and then tried to render another, it would instead render the first.