### PR TITLE
Finish canary support

### DIFF
--- a/lib/with_ember_app/assets/builder.rb
+++ b/lib/with_ember_app/assets/builder.rb
@@ -6,6 +6,7 @@ module WithEmberApp
       # When building for multiple apps
       array   :names, default: -> { [] }
       hash    :globals, strip: false, default: -> { {} }
+      boolean :canary, default: false
 
       validate :all_names_present
 
@@ -33,7 +34,7 @@ module WithEmberApp
 
       # @return [<String>]
       def asset_links
-        all_names.map { |app| WithEmberApp.fetch app }
+        all_names.map { |app| WithEmberApp.fetch app, canary: canary }
       end
 
       # @return [String]

--- a/lib/with_ember_app/helper.rb
+++ b/lib/with_ember_app/helper.rb
@@ -7,7 +7,8 @@ module WithEmberApp
     # @option kwargs [Hash]     payload
     # @return [String]
     def with_ember_app(loading_spinner: true, timeout_page: false, **kwargs)
-      assets = Assets::Builder.run! **kwargs
+      canary = kwargs[:canary] || request.params[:canary]
+      assets = Assets::Builder.run! canary: canary, **kwargs
       options = WithEmberApp
 
       render(partial: 'with_ember_app/loading_template', locals: {

--- a/spec/with_ember_app_spec.rb
+++ b/spec/with_ember_app_spec.rb
@@ -189,15 +189,15 @@ describe WithEmberApp do
       end
 
       it 'fetches assets' do
-        expect(WithEmberApp).to receive(:fetch).with('foo').and_return('<bar-script-baz>')
+        expect(WithEmberApp).to receive(:fetch).with('foo', { canary: false }).and_return('<bar-script-baz>')
 
         results = service.run! name: 'foo'
         expect(results.to_s).to include('bar-script-baz')
       end
 
       it 'works with an array of names' do
-        expect(WithEmberApp).to receive(:fetch).with('foo').and_return('<foo-script-baz>')
-        expect(WithEmberApp).to receive(:fetch).with('bar').and_return('<bar-script-baz>')
+        expect(WithEmberApp).to receive(:fetch).with('foo', { canary: false }).and_return('<foo-script-baz>')
+        expect(WithEmberApp).to receive(:fetch).with('bar', { canary: false }).and_return('<bar-script-baz>')
 
         result = service.run!(names: ['foo', 'bar']).to_s
         expect(result).to include('foo-script-baz')


### PR DESCRIPTION
When we built the `WithEmberApp` gem, canary support was left incomplete.  (To be fair, this concept was something we never really used!)

Now that we are on AWS, we need this feature so that we test new UI's on the edge environment (since it shares Redis with the rest of production).

The goal here is that the `with_ember_app` helper can accept a `canary` attribute, and/or load it automatically from the `request.params` object.  It'll then pass this along to the adapter.